### PR TITLE
Use specific version for Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine
+FROM alpine:3.6
 COPY ./entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Tested by building Docker image and running container locally.

```
docker build -t random-logger .
Sending build context to Docker daemon  87.55kB
Step 1/3 : FROM alpine:3.6
3.6: Pulling from library/alpine
88286f41530e: Pull complete
Digest: sha256:f006ecbb824d87947d0b51ab8488634bf69fe4094959d935c0c103f4820a417d
Status: Downloaded newer image for alpine:3.6
 ---> 76da55c8019d
Step 2/3 : COPY ./entrypoint.sh /
 ---> 61f6c317e034
Removing intermediate container 0fae90a1af20
Step 3/3 : ENTRYPOINT /entrypoint.sh
 ---> Running in 162ad23d5f64
 ---> 70df71578aad
Removing intermediate container 162ad23d5f64
Successfully built 70df71578aad
Successfully tagged random-logger:latest
```

https://github.com/chentex/random-logger/issues/2